### PR TITLE
unhardcode GNU/Linux desktop launcher icon file path

### DIFF
--- a/patchmatrix.desktop.in
+++ b/patchmatrix.desktop.in
@@ -3,6 +3,6 @@ Name=PatchMatrix
 Comment=Connect JACK clients together
 Exec=@prefix@/@bindir@/patchmatrix
 Terminal=false
-Icon=@prefix@/@datadir@/icons/hicolor/256x256/apps/patchmatrix.png
+Icon=patchmatrix
 Type=Application
 Categories=AudioVideo;Audio;


### PR DESCRIPTION
Since the icon is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the icon file extension in the `.desktop` launcher. It will be found anyway.

This facilitates icon theming and makes the system automatically pickup the appropriate icon size if different sizes are provided in ``.../icons/hicolor/<size>/apps``.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).