### PR TITLE
Add option for custom JACK client names to mixer and monitor.

### DIFF
--- a/patchmatrix_mixer.1
+++ b/patchmatrix_mixer.1
@@ -45,6 +45,11 @@ Number of output ports (1-128)
 .IP
 Connect to named JACK daemon
 
+.HP
+\fB\-c\fR client-name
+.IP
+JACK client name to use
+
 .SH LICENSE
 Artistic License 2.0.
 

--- a/patchmatrix_mixer.c
+++ b/patchmatrix_mixer.c
@@ -384,6 +384,7 @@ main(int argc, char **argv)
 	const size_t total_size = sizeof(mixer_shm_t);
 
 	const char *server_name = NULL;
+	const char *client_name = PATCHMATRIX_MIXER_ID;
 	unsigned nsinks = 1;
 	unsigned nsources = 1;
 	mixer.type = TYPE_AUDIO;
@@ -394,7 +395,7 @@ main(int argc, char **argv)
 		"Released under Artistic License 2.0 by Open Music Kontrollers\n", argv[0]);
 
 	int c;
-	while((c = getopt(argc, argv, "vht:i:o:n:")) != -1)
+	while((c = getopt(argc, argv, "vht:i:o:n:c:")) != -1)
 	{
 		switch(c)
 		{
@@ -426,7 +427,8 @@ main(int argc, char **argv)
 					"   [-t] port-type       port type (audio, midi)\n"
 					"   [-i] input-num       port input number (1-%i)\n"
 					"   [-o] output-num      port output number (1-%i)\n"
-					"   [-n] server-name     connect to named JACK daemon\n\n"
+					"   [-n] server-name     connect to named JACK daemon\n"
+					"   [-c] client-name     JACK client name to use\n\n"
 					, argv[0], PORT_MAX, PORT_MAX);
 				return 0;
 			case 'n':
@@ -444,6 +446,9 @@ main(int argc, char **argv)
 				nsources = atoi(optarg);
 				if(nsources > PORT_MAX)
 					nsources = PORT_MAX;
+				break;
+			case 'c':
+				client_name = optarg;
 				break;
 			case '?':
 				if( (optopt == 'n') || (optopt == 'u') || (optopt == 't')
@@ -464,7 +469,7 @@ main(int argc, char **argv)
 		opts |= JackServerName;
 
 	jack_status_t status;
-	mixer.client = jack_client_open(PATCHMATRIX_MIXER_ID, opts, &status,
+	mixer.client = jack_client_open(client_name, opts, &status,
 		server_name ? server_name : NULL);
 	if(!mixer.client)
 		return -1;
@@ -542,7 +547,7 @@ main(int argc, char **argv)
 		mixer.jsources[j] = jsource;
 	}
 
-	const char *client_name = jack_get_client_name(mixer.client);
+	client_name = jack_get_client_name(mixer.client);
 	const int fd = shm_open(client_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	if(fd != -1)
 	{

--- a/patchmatrix_monitor.1
+++ b/patchmatrix_monitor.1
@@ -40,6 +40,11 @@ Number of input ports (1-128)
 .IP
 Connect to named JACK daemon
 
+.HP
+\fB\-c\fR client-name
+.IP
+JACK client name to use
+
 .SH LICENSE
 Artistic License 2.0.
 

--- a/patchmatrix_monitor.c
+++ b/patchmatrix_monitor.c
@@ -163,6 +163,7 @@ main(int argc, char **argv)
 	static monitor_app_t monitor;
 	const size_t total_size = sizeof(monitor_shm_t);
 
+	const char *client_name = PATCHMATRIX_MONITOR_ID;
 	const char *server_name = NULL;
 	unsigned nsinks = 1;
 	monitor.type = TYPE_AUDIO;
@@ -173,7 +174,7 @@ main(int argc, char **argv)
 		"Released under Artistic License 2.0 by Open Music Kontrollers\n", argv[0]);
 
 	int c;
-	while((c = getopt(argc, argv, "vht:i:n:")) != -1)
+	while((c = getopt(argc, argv, "vht:i:n:c:")) != -1)
 	{
 		switch(c)
 		{
@@ -204,7 +205,9 @@ main(int argc, char **argv)
 					"   [-h]                 print usage information\n"
 					"   [-t] port-type       port type (audio, midi)\n"
 					"   [-i] input-num       port input number (1-%i)\n"
-					"   [-n] server-name     connect to named JACK daemon\n\n"
+					"   [-n] server-name     connect to named JACK daemon\n"
+					"   [-c] client-name     JACK client name to use\n\n"
+
 					, argv[0], PORT_MAX);
 				return 0;
 			case 'n':
@@ -217,6 +220,9 @@ main(int argc, char **argv)
 				nsinks = atoi(optarg);
 				if(nsinks > PORT_MAX)
 					nsinks = PORT_MAX;
+				break;
+			case 'c':
+				client_name = optarg;
 				break;
 			case '?':
 				if( (optopt == 'n') || (optopt == 'u') || (optopt == 't')
@@ -237,7 +243,7 @@ main(int argc, char **argv)
 		opts |= JackServerName;
 
 	jack_status_t status;
-	monitor.client = jack_client_open(PATCHMATRIX_MONITOR_ID, opts, &status,
+	monitor.client = jack_client_open(client_name, opts, &status,
 		server_name ? server_name : NULL);
 	if(!monitor.client)
 		return -1;
@@ -271,7 +277,7 @@ main(int argc, char **argv)
 		monitor.jsinks[i] = jsink;
 	}
 
-	const char *client_name = jack_get_client_name(monitor.client);
+	client_name = jack_get_client_name(monitor.client);
 	const int fd = shm_open(client_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	if(fd != -1)
 	{


### PR DESCRIPTION
The patchmatrix mixer and monitor applications are great and I would love to use them outside the patchmatrix application.

The only thing I'm missing is an option to start them with a custom client name in jack. Without this option it is hard to use them programmatically, because if multiple instances are started, their names will be generated by jack and thus hard to find out.

I added this option with an optional -c flag in both the mixer and monitor, and tested that they work as intended. I hope you will consider pulling this change in to make these tools just a bit better.